### PR TITLE
refact: capitalize env variables to showup in documentation

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -4,6 +4,7 @@ name: Unit Testing
 on:
   pull_request:
     paths: 
+      - 'env/**'
       - 'utils/**'
       - 'go.*'
       - '.github/workflows/unit-testing.yml'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Matter Snap Testing
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/canonical/matter-snap-testing.svg)](https://pkg.go.dev/github.com/canonical/matter-snap-testing)
+
 Utility package for testing Matter snaps in Go.
 
 Test the testing utils:

--- a/env/env.go
+++ b/env/env.go
@@ -8,14 +8,14 @@ import (
 // Environment variables, used to override defaults
 const (
 	// Channel/Revision of the service snap (has default)
-	envSnapChannel = "SNAP_CHANNEL"
+	EnvSnapChannel = "SNAP_CHANNEL"
 
 	// Path to snap instead, used for testing a local snap instead of
 	// downloading from the store
-	envSnapPath = "SNAP_PATH"
+	EnvSnapPath = "SNAP_PATH"
 
 	// Toggle the teardown operations during tests (has default)
-	envTeardown = "TEARDOWN"
+	EnvTeardown = "TEARDOWN"
 )
 
 var (
@@ -47,15 +47,15 @@ func init() {
 // Read environment variables and perform type conversion/casting
 func loadEnvVars() {
 
-	if v := os.Getenv(envSnapChannel); v != "" {
+	if v := os.Getenv(EnvSnapChannel); v != "" {
 		snapChannel = v
 	}
 
-	if v := os.Getenv(envSnapPath); v != "" {
+	if v := os.Getenv(EnvSnapPath); v != "" {
 		snapPath = v
 	}
 
-	if v := os.Getenv(envTeardown); v != "" {
+	if v := os.Getenv(EnvTeardown); v != "" {
 		var err error
 		teardown, err = strconv.ParseBool(v)
 		if err != nil {


### PR DESCRIPTION
Go doc doesn't show internal functions, in order to be able to document the needed env vars it's necessary to capitalize it.

- Exports environment variables to be documented [1]
- Add reference banner

fixes #14 

[1] Like shown in [this discussion](https://github.com/golang/go/issues/7823), Golang doesn't export documentation (to pkg.go.dev) on unexported variables. 