### PR TITLE
Add log file writing functions

### DIFF
--- a/utils/logs.go
+++ b/utils/logs.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func GetLogFileName(t *testing.T, label string) string {
+	fileName := strings.ReplaceAll(t.Name(), "/", "-") + "-" + label + ".log"
+	logDirectory := "logs"
+
+	err := os.MkdirAll(logDirectory, 0777)
+	if err != nil {
+		t.Fatalf("can't create log directory")
+	}
+
+	return logDirectory + "/" + fileName
+}
+
+func WriteLogFile(t *testing.T, label string, b []byte) error {
+	return os.WriteFile(
+		GetLogFileName(t, label),
+		b,
+		0777,
+	)
+}

--- a/utils/snap.go
+++ b/utils/snap.go
@@ -124,14 +124,15 @@ func snapJournalCommand(start time.Time, name string) string {
 		name)
 }
 
-func SnapDumpLogs(t *testing.T, start time.Time, name string) {
-	filename := name + ".log" // used in action.yml
+func SnapDumpLogs(t *testing.T, start time.Time, snapName string) {
+	logFileName := GetLogFileName(t, snapName)
+
 	ExecVerbose(t, fmt.Sprintf("(%s) > %s",
-		snapJournalCommand(start, name),
-		filename))
+		snapJournalCommand(start, snapName),
+		logFileName))
 
 	wd, _ := os.Getwd()
-	fmt.Printf("Wrote snap logs to %s/%s\n", wd, filename)
+	fmt.Printf("Wrote snap logs to %s/%s\n", wd, logFileName)
 }
 
 func SnapLogs(t *testing.T, start time.Time, name string) string {


### PR DESCRIPTION
Moving the writing of log files to this package, as we can then use a consistent file naming scheme across all the tests.