### PR TITLE
Allow nil test in logging

### DIFF
--- a/utils/log.go
+++ b/utils/log.go
@@ -7,7 +7,10 @@ import (
 )
 
 func logFileName(t *testing.T, label string) string {
-	fileName := strings.ReplaceAll(t.Name(), "/", "-") + "-" + label + ".log"
+	fileName := label + ".log"
+	if t != nil {
+		fileName = strings.ReplaceAll(t.Name(), "/", "-") + "-" + fileName
+	}
 	logDirectory := "logs"
 
 	err := os.MkdirAll(logDirectory, 0777)


### PR DESCRIPTION
In a test setup and teardown function we do not have a `testing.T` instance we can pass to the logging function. This update allows for a nil value to be passed, using only the label in the file name.